### PR TITLE
feat: initial Go CLI skeleton for Uncompact

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,108 @@
 # Uncompact
+
+Uncompact prevents Claude Code compaction from degrading your workflow. Instead of losing context at the end of a context window, Uncompact re-injects a dense Markdown "context bomb" via Claude Code hooks — powered by the [Supermodel Public API](https://dashboard.supermodeltools.com).
+
+## How It Works
+
+1. Uncompact registers as a Claude Code hook
+2. When a hook fires (post-compaction, session start, etc.), Uncompact fetches your project graph from the Supermodel API
+3. It renders a prioritized Markdown context bomb (≤2,000 tokens by default) and injects it back into your Claude Code session
+
+## Prerequisites
+
+- A Supermodel subscription — get your API key at [dashboard.supermodeltools.com](https://dashboard.supermodeltools.com)
+- Go 1.22+ (for building from source) or download a pre-built binary from Releases
+
+## Installation
+
+### 1. Install the binary
+
+```bash
+go install github.com/supermodeltools/uncompact@latest
+```
+
+### 2. Set your API key
+
+```bash
+export SUPERMODEL_API_KEY=<your-key>
+```
+
+Add this to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.) to persist it.
+
+### 3. Install hooks into Claude Code
+
+```bash
+uncompact install
+```
+
+This detects your `settings.json` location, merges the Uncompact hooks without clobbering existing configuration, and shows a diff before writing.
+
+Or use the guided setup wizard:
+
+```bash
+uncompact init
+```
+
+### Manual hook configuration
+
+Add the following to your Claude Code `settings.json` (see the [hooks guide](https://code.claude.com/docs/en/hooks-guide#re-inject-context-after-compaction)):
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uncompact run"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Usage
+
+```
+uncompact run              # Generate and output a context bomb (used by hooks)
+uncompact dry-run          # Preview what would be injected without writing
+uncompact install          # Merge hooks into Claude Code settings.json
+uncompact init             # Interactive setup wizard
+uncompact verify-install   # Check hook configuration is correct
+uncompact status           # Show last injection time, token size, cache freshness
+uncompact logs             # View recent activity
+uncompact stats            # Token usage, cache hit rate, API call count
+```
+
+### Flags
+
+```
+--max-tokens N     Cap context bomb output (default: 2000)
+--force-refresh    Bypass cache and fetch fresh data from API
+--fallback         Emit minimal static context if full mode fails
+--debug            Enable debug logging
+```
+
+## Architecture
+
+- **CLI**: Go + [Cobra](https://github.com/spf13/cobra)
+- **Cache**: SQLite via `mattn/go-sqlite3` — versioned graph snapshots with TTL, staleness warnings, and a 100MB storage cap
+- **API**: Supermodel Public API — subscription auth via Bearer token
+- **Output**: Prompt templating (`text/template`) linearizes the JSON graph into prioritized Markdown sections
+
+### Graceful degradation
+
+When the API is unavailable, Uncompact serves the last successful cached output (with a `[STALE]` prefix). If both the API and cache are unavailable, it exits silently (exit 0, no output) to avoid blocking your Claude Code session.
+
+## Development
+
+```bash
+git clone https://github.com/supermodeltools/uncompact
+cd uncompact
+go build ./...
+go test ./...
+```

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/supermodeltools/uncompact/internal/install"
+)
+
+var installCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install Uncompact hooks into Claude Code settings.json",
+	Long: `Detect the Claude Code settings.json location, merge the Uncompact
+hooks configuration without clobbering existing entries, and show a diff
+for review before writing.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		return install.Run(dryRun)
+	},
+}
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Interactive setup wizard for first-time configuration",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return install.Init()
+	},
+}
+
+var verifyCmd = &cobra.Command{
+	Use:   "verify-install",
+	Short: "Validate that hooks are correctly configured",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ok, issues := install.Verify()
+		if len(issues) > 0 {
+			for _, issue := range issues {
+				fmt.Println("  ✗", issue)
+			}
+			return fmt.Errorf("installation verification failed")
+		}
+		if ok {
+			fmt.Println("✓ Uncompact hooks are correctly configured")
+		}
+		return nil
+	},
+}
+
+func init() {
+	installCmd.Flags().Bool("dry-run", false, "show what would be written without making changes")
+	rootCmd.AddCommand(installCmd)
+	rootCmd.AddCommand(initCmd)
+	rootCmd.AddCommand(verifyCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "uncompact",
+	Short: "Re-inject context into Claude Code after compaction",
+	Long: `Uncompact prevents Claude Code compaction from degrading your workflow.
+It generates a "context bomb" — a dense Markdown prompt re-injected into
+your Claude Code session via hooks, powered by the Supermodel Public API.`,
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	rootCmd.PersistentFlags().IntP("max-tokens", "t", 2000, "maximum tokens for context bomb output")
+	rootCmd.PersistentFlags().Bool("force-refresh", false, "bypass cache and fetch fresh data from API")
+	rootCmd.PersistentFlags().Bool("fallback", false, "emit minimal static context if full mode fails")
+	rootCmd.PersistentFlags().Bool("debug", false, "enable debug logging")
+
+	if err := rootCmd.PersistentFlags().MarkHidden("debug"); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not hide debug flag: %v\n", err)
+	}
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/supermodeltools/uncompact/internal/api"
+	"github.com/supermodeltools/uncompact/internal/db"
+	"github.com/supermodeltools/uncompact/internal/output"
+)
+
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Generate and output a context bomb",
+	Long:  `Fetch context from the Supermodel API (or cache), render it as Markdown, and print to stdout for hook injection.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		maxTokens, _ := cmd.Flags().GetInt("max-tokens")
+		forceRefresh, _ := cmd.Flags().GetBool("force-refresh")
+		fallback, _ := cmd.Flags().GetBool("fallback")
+
+		store, err := db.Open("")
+		if err != nil {
+			if fallback {
+				fmt.Print(output.FallbackContext())
+				return nil
+			}
+			return nil // silent pass-through — don't block Claude session
+		}
+		defer store.Close()
+
+		client := api.NewClient()
+
+		graph, err := client.FetchGraph(cmd.Context(), forceRefresh, store)
+		if err != nil {
+			if fallback {
+				fmt.Print(output.FallbackContext())
+				return nil
+			}
+			// Serve stale cache if available
+			cached, cacheErr := store.GetLatest()
+			if cacheErr != nil || cached == nil {
+				return nil // silent pass-through
+			}
+			graph, err = api.GraphFromRecord(cached)
+			if err != nil {
+				return nil
+			}
+		}
+
+		bomb, err := output.RenderContextBomb(graph, maxTokens)
+		if err != nil {
+			return nil // silent pass-through
+		}
+
+		fmt.Print(bomb)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(runCmd)
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/supermodeltools/uncompact/internal/db"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show last injection time, token size, and cache freshness",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		store, err := db.Open("")
+		if err != nil {
+			return fmt.Errorf("could not open cache: %w", err)
+		}
+		defer store.Close()
+
+		latest, err := store.GetLatest()
+		if err != nil || latest == nil {
+			fmt.Println("No cached context found. Run `uncompact run` to fetch context.")
+			return nil
+		}
+
+		age := time.Since(latest.FetchedAt)
+		stale := ""
+		if age > latest.TTL {
+			stale = " [STALE]"
+		}
+
+		fmt.Printf("Last fetch:   %s (%s ago)%s\n", latest.FetchedAt.Format(time.RFC3339), formatDuration(age), stale)
+		fmt.Printf("Token size:   ~%d tokens\n", latest.EstimatedTokens)
+		fmt.Printf("Cache TTL:    %s\n", latest.TTL)
+		fmt.Printf("Source:       %s\n", latest.Source)
+		return nil
+	},
+}
+
+var statsCmd = &cobra.Command{
+	Use:   "stats",
+	Short: "Show token usage, cache hit rate, and API call count",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		store, err := db.Open("")
+		if err != nil {
+			return fmt.Errorf("could not open cache: %w", err)
+		}
+		defer store.Close()
+
+		stats, err := store.GetStats()
+		if err != nil {
+			return fmt.Errorf("could not read stats: %w", err)
+		}
+
+		fmt.Printf("Total injections:  %d\n", stats.TotalInjections)
+		fmt.Printf("Cache hits:        %d (%.1f%%)\n", stats.CacheHits, stats.CacheHitRate()*100)
+		fmt.Printf("API calls:         %d\n", stats.APICalls)
+		fmt.Printf("Avg token size:    %d\n", stats.AvgTokens)
+		fmt.Printf("Total tokens used: %d\n", stats.TotalTokens)
+		return nil
+	},
+}
+
+var logsCmd = &cobra.Command{
+	Use:   "logs",
+	Short: "View recent Uncompact activity",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		tail, _ := cmd.Flags().GetInt("tail")
+		store, err := db.Open("")
+		if err != nil {
+			return fmt.Errorf("could not open cache: %w", err)
+		}
+		defer store.Close()
+
+		entries, err := store.GetLogs(tail)
+		if err != nil {
+			return fmt.Errorf("could not read logs: %w", err)
+		}
+		if len(entries) == 0 {
+			fmt.Println("No log entries found.")
+			return nil
+		}
+		for _, e := range entries {
+			fmt.Printf("[%s] %s — %d tokens (%s)\n",
+				e.Timestamp.Format("2006-01-02 15:04:05"), e.Event, e.Tokens, e.Source)
+		}
+		return nil
+	},
+}
+
+var dryRunCmd = &cobra.Command{
+	Use:   "dry-run",
+	Short: "Show what would be injected without writing anything",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Delegate to run with dry-run flag behavior: print output but annotate it
+		fmt.Println("--- DRY RUN: context bomb that would be injected ---")
+		// Reuse run logic
+		return runCmd.RunE(cmd, args)
+	},
+}
+
+func formatDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	return fmt.Sprintf("%dh", int(d.Hours()))
+}
+
+func init() {
+	logsCmd.Flags().Int("tail", 50, "number of recent log entries to show")
+	rootCmd.AddCommand(statusCmd)
+	rootCmd.AddCommand(statsCmd)
+	rootCmd.AddCommand(logsCmd)
+	rootCmd.AddCommand(dryRunCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,15 @@
+module github.com/supermodeltools/uncompact
+
+go 1.22
+
+require (
+	github.com/spf13/cobra v1.8.0
+	github.com/mattn/go-sqlite3 v1.14.22
+	github.com/aymerick/raymond v2.0.2+incompatible
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,0 +1,166 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/supermodeltools/uncompact/internal/db"
+)
+
+const (
+	baseURL        = "https://api.supermodeltools.com"
+	defaultTimeout = 10 * time.Second
+	authEnvVar     = "SUPERMODEL_API_KEY"
+	dashboardURL   = "https://dashboard.supermodeltools.com"
+)
+
+// Client is the Supermodel API client.
+type Client struct {
+	httpClient *http.Client
+	apiKey     string
+	baseURL    string
+}
+
+// Graph represents the context graph returned by the Supermodel API.
+type Graph struct {
+	ProjectID string         `json:"project_id"`
+	FetchedAt time.Time      `json:"fetched_at"`
+	TTL       time.Duration  `json:"ttl"`
+	Source    string         `json:"source"`
+	Sections  []GraphSection `json:"sections"`
+}
+
+// GraphSection is a prioritized section of context within a Graph.
+type GraphSection struct {
+	ID         string  `json:"id"`
+	Title      string  `json:"title"`
+	Content    string  `json:"content"`
+	Priority   string  `json:"priority"` // "required" or "optional"
+	Confidence float64 `json:"confidence"`
+	Tokens     int     `json:"tokens"`
+	Source     string  `json:"source"`
+}
+
+// NewClient creates a new Supermodel API client.
+// The API key is read from SUPERMODEL_API_KEY, falling back to ~/.uncompact/config.
+func NewClient() *Client {
+	return &Client{
+		httpClient: &http.Client{Timeout: defaultTimeout},
+		apiKey:     loadAPIKey(),
+		baseURL:    baseURL,
+	}
+}
+
+// FetchGraph retrieves the context graph from the API or the local cache.
+func (c *Client) FetchGraph(ctx context.Context, forceRefresh bool, store *db.Store) (*Graph, error) {
+	if !forceRefresh {
+		cached, err := store.GetLatest()
+		if err == nil && cached != nil {
+			age := time.Since(cached.FetchedAt)
+			if age < cached.TTL {
+				return graphFromRecord(cached)
+			}
+		}
+	}
+
+	if c.apiKey == "" {
+		return nil, fmt.Errorf("no API key found; subscribe and get your key at %s", dashboardURL)
+	}
+
+	graph, err := c.fetchFromAPI(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if storeErr := c.cacheGraph(store, graph); storeErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not cache graph: %v\n", storeErr)
+	}
+
+	return graph, nil
+}
+
+func (c *Client) fetchFromAPI(ctx context.Context) (*Graph, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/graph", nil)
+	if err != nil {
+		return nil, fmt.Errorf("building request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "uncompact/0.1.0")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		return nil, fmt.Errorf("invalid API key; manage your subscription at %s", dashboardURL)
+	case http.StatusPaymentRequired:
+		return nil, fmt.Errorf("subscription required; subscribe at %s", dashboardURL)
+	case http.StatusOK:
+		// continue
+	default:
+		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
+	}
+
+	var graph Graph
+	if err := json.NewDecoder(resp.Body).Decode(&graph); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	graph.FetchedAt = time.Now()
+	if graph.TTL == 0 {
+		graph.TTL = time.Hour
+	}
+	graph.Source = "api"
+
+	return &graph, nil
+}
+
+func (c *Client) cacheGraph(store *db.Store, graph *Graph) error {
+	data, err := json.Marshal(graph)
+	if err != nil {
+		return err
+	}
+
+	tokens := 0
+	for _, s := range graph.Sections {
+		tokens += s.Tokens
+	}
+
+	record := &db.GraphRecord{
+		ProjectID:       graph.ProjectID,
+		FetchedAt:       graph.FetchedAt,
+		TTL:             graph.TTL,
+		Source:          graph.Source,
+		EstimatedTokens: tokens,
+		Data:            data,
+	}
+	return store.SaveRecord(record)
+}
+
+// GraphFromRecord deserializes a cached GraphRecord back into a Graph.
+func GraphFromRecord(r *db.GraphRecord) (*Graph, error) {
+	var g Graph
+	if err := json.Unmarshal(r.Data, &g); err != nil {
+		return nil, fmt.Errorf("deserializing cached graph: %w", err)
+	}
+	g.FetchedAt = r.FetchedAt
+	g.TTL = r.TTL
+	g.Source = "cache"
+	return &g, nil
+}
+
+func loadAPIKey() string {
+	if key := os.Getenv(authEnvVar); key != "" {
+		return key
+	}
+	// TODO: read from ~/.uncompact/config
+	return ""
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1,0 +1,235 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Store manages the local SQLite cache of graph outputs.
+type Store struct {
+	db *sql.DB
+}
+
+// GraphRecord is a stored graph snapshot.
+type GraphRecord struct {
+	ID              int64
+	ProjectID       string
+	FetchedAt       time.Time
+	TTL             time.Duration
+	Source          string
+	EstimatedTokens int
+	Data            []byte
+}
+
+// Stats holds aggregate usage statistics.
+type Stats struct {
+	TotalInjections int64
+	CacheHits       int64
+	APICalls        int64
+	AvgTokens       int64
+	TotalTokens     int64
+}
+
+// CacheHitRate returns the fraction of injections served from cache.
+func (s *Stats) CacheHitRate() float64 {
+	if s.TotalInjections == 0 {
+		return 0
+	}
+	return float64(s.CacheHits) / float64(s.TotalInjections)
+}
+
+// LogEntry is a single activity log record.
+type LogEntry struct {
+	ID        int64
+	Timestamp time.Time
+	Event     string
+	Tokens    int
+	Source    string
+}
+
+// Open opens (or creates) the SQLite database at the default path,
+// or at the provided path if non-empty.
+func Open(path string) (*Store, error) {
+	if path == "" {
+		var err error
+		path, err = defaultDBPath()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return nil, fmt.Errorf("creating data directory: %w", err)
+	}
+
+	sqlDB, err := sql.Open("sqlite3", path+"?_journal_mode=WAL")
+	if err != nil {
+		return nil, fmt.Errorf("opening database: %w", err)
+	}
+
+	store := &Store{db: sqlDB}
+	if err := store.migrate(); err != nil {
+		sqlDB.Close()
+		return nil, fmt.Errorf("running migrations: %w", err)
+	}
+	return store, nil
+}
+
+// Close closes the underlying database connection.
+func (s *Store) Close() error {
+	return s.db.Close()
+}
+
+// SaveRecord stores a new graph snapshot, pruning old records if needed.
+func (s *Store) SaveRecord(record *GraphRecord) error {
+	_, err := s.db.Exec(`
+		INSERT INTO graphs (project_id, fetched_at, ttl_seconds, source, estimated_tokens, data)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		record.ProjectID,
+		record.FetchedAt.Unix(),
+		int64(record.TTL.Seconds()),
+		record.Source,
+		record.EstimatedTokens,
+		record.Data,
+	)
+	if err != nil {
+		return fmt.Errorf("inserting graph: %w", err)
+	}
+
+	return s.pruneIfOverLimit()
+}
+
+// GetLatest returns the most recently stored graph record, or nil if none exists.
+func (s *Store) GetLatest() (*GraphRecord, error) {
+	row := s.db.QueryRow(`
+		SELECT id, project_id, fetched_at, ttl_seconds, source, estimated_tokens, data
+		FROM graphs
+		ORDER BY fetched_at DESC
+		LIMIT 1`)
+
+	return scanRecord(row)
+}
+
+// GetStats returns aggregate statistics.
+func (s *Store) GetStats() (*Stats, error) {
+	var stats Stats
+	err := s.db.QueryRow(`
+		SELECT
+			COALESCE(SUM(injection_count), 0),
+			COALESCE(SUM(cache_hits), 0),
+			COALESCE(SUM(api_calls), 0),
+			COALESCE(AVG(avg_tokens), 0),
+			COALESCE(SUM(total_tokens), 0)
+		FROM stats`).Scan(
+		&stats.TotalInjections,
+		&stats.CacheHits,
+		&stats.APICalls,
+		&stats.AvgTokens,
+		&stats.TotalTokens,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &stats, nil
+}
+
+// GetLogs returns the most recent n log entries.
+func (s *Store) GetLogs(n int) ([]*LogEntry, error) {
+	rows, err := s.db.Query(`
+		SELECT id, timestamp, event, tokens, source
+		FROM logs
+		ORDER BY timestamp DESC
+		LIMIT ?`, n)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var entries []*LogEntry
+	for rows.Next() {
+		var e LogEntry
+		var ts int64
+		if err := rows.Scan(&e.ID, &ts, &e.Event, &e.Tokens, &e.Source); err != nil {
+			return nil, err
+		}
+		e.Timestamp = time.Unix(ts, 0)
+		entries = append(entries, &e)
+	}
+	return entries, rows.Err()
+}
+
+func (s *Store) migrate() error {
+	_, err := s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS schema_version (version INTEGER PRIMARY KEY);
+
+		CREATE TABLE IF NOT EXISTS graphs (
+			id               INTEGER PRIMARY KEY AUTOINCREMENT,
+			project_id       TEXT    NOT NULL DEFAULT '',
+			fetched_at       INTEGER NOT NULL,
+			ttl_seconds      INTEGER NOT NULL DEFAULT 3600,
+			source           TEXT    NOT NULL DEFAULT 'api',
+			estimated_tokens INTEGER NOT NULL DEFAULT 0,
+			data             BLOB    NOT NULL
+		);
+
+		CREATE TABLE IF NOT EXISTS logs (
+			id        INTEGER PRIMARY KEY AUTOINCREMENT,
+			timestamp INTEGER NOT NULL,
+			event     TEXT    NOT NULL,
+			tokens    INTEGER NOT NULL DEFAULT 0,
+			source    TEXT    NOT NULL DEFAULT ''
+		);
+
+		CREATE TABLE IF NOT EXISTS stats (
+			id               INTEGER PRIMARY KEY DEFAULT 1,
+			injection_count  INTEGER NOT NULL DEFAULT 0,
+			cache_hits       INTEGER NOT NULL DEFAULT 0,
+			api_calls        INTEGER NOT NULL DEFAULT 0,
+			avg_tokens       INTEGER NOT NULL DEFAULT 0,
+			total_tokens     INTEGER NOT NULL DEFAULT 0
+		);
+
+		INSERT OR IGNORE INTO stats (id) VALUES (1);
+	`)
+	return err
+}
+
+func (s *Store) pruneIfOverLimit() error {
+	_, err := s.db.Exec(`
+		DELETE FROM graphs
+		WHERE id NOT IN (
+			SELECT id FROM graphs ORDER BY fetched_at DESC LIMIT 1000
+		)`)
+	return err
+}
+
+func defaultDBPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("could not find home directory: %w", err)
+	}
+	return filepath.Join(home, ".uncompact", "cache.db"), nil
+}
+
+func scanRecord(row *sql.Row) (*GraphRecord, error) {
+	var r GraphRecord
+	var fetchedAt int64
+	var ttlSeconds int64
+
+	err := row.Scan(&r.ID, &r.ProjectID, &fetchedAt, &ttlSeconds, &r.Source, &r.EstimatedTokens, &r.Data)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	r.FetchedAt = time.Unix(fetchedAt, 0)
+	r.TTL = time.Duration(ttlSeconds) * time.Second
+	return &r, nil
+}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -1,0 +1,167 @@
+package install
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// HooksConfig is the Uncompact hooks block to merge into settings.json.
+var HooksConfig = map[string]interface{}{
+	"hooks": map[string]interface{}{
+		"PostToolUse": []map[string]interface{}{
+			{
+				"matcher": "Bash",
+				"hooks": []map[string]interface{}{
+					{
+						"type":    "command",
+						"command": "uncompact run",
+					},
+				},
+			},
+		},
+		"PreToolUse": []map[string]interface{}{},
+	},
+}
+
+// Run merges Uncompact hooks into settings.json. If dryRun is true, it only prints
+// the diff without writing.
+func Run(dryRun bool) error {
+	settingsPath, err := findSettingsJSON()
+	if err != nil {
+		return fmt.Errorf("could not locate Claude Code settings.json: %w\n\nInstall Claude Code first: https://claude.ai/code", err)
+	}
+
+	current, err := readJSON(settingsPath)
+	if err != nil {
+		// File may not exist yet; start fresh
+		current = map[string]interface{}{}
+	}
+
+	merged := mergeHooks(current, HooksConfig)
+	mergedBytes, err := json.MarshalIndent(merged, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling merged config: %w", err)
+	}
+
+	fmt.Printf("Settings file: %s\n\n", settingsPath)
+	fmt.Println("--- changes to be applied ---")
+	printDiff(current, merged)
+
+	if dryRun {
+		fmt.Println("\n(dry-run: no changes written)")
+		return nil
+	}
+
+	if err := os.WriteFile(settingsPath, append(mergedBytes, '\n'), 0600); err != nil {
+		return fmt.Errorf("writing settings.json: %w", err)
+	}
+
+	fmt.Println("\n✓ Hooks installed successfully.")
+	fmt.Println("  Uncompact will re-inject context on configured hook events.")
+	return nil
+}
+
+// Init runs an interactive first-time setup wizard.
+func Init() error {
+	fmt.Println("Uncompact Setup Wizard")
+	fmt.Println("======================")
+	fmt.Println()
+	fmt.Printf("1. Get your API key at: https://dashboard.supermodeltools.com\n")
+	fmt.Printf("2. Set it as an environment variable:\n")
+	fmt.Printf("   export SUPERMODEL_API_KEY=<your-key>\n")
+	fmt.Println()
+	fmt.Println("3. Installing hooks into Claude Code settings.json...")
+	return Run(false)
+}
+
+// Verify checks whether the hooks are correctly installed. Returns true if ok,
+// plus any issues found.
+func Verify() (bool, []string) {
+	settingsPath, err := findSettingsJSON()
+	if err != nil {
+		return false, []string{"could not locate settings.json: " + err.Error()}
+	}
+
+	settings, err := readJSON(settingsPath)
+	if err != nil {
+		return false, []string{"could not read settings.json: " + err.Error()}
+	}
+
+	var issues []string
+
+	hooks, ok := settings["hooks"].(map[string]interface{})
+	if !ok {
+		issues = append(issues, "hooks key missing from settings.json")
+		return false, issues
+	}
+
+	postToolUse, ok := hooks["PostToolUse"].([]interface{})
+	if !ok || len(postToolUse) == 0 {
+		issues = append(issues, "PostToolUse hook not configured")
+	}
+
+	return len(issues) == 0, issues
+}
+
+func findSettingsJSON() (string, error) {
+	var base string
+	switch runtime.GOOS {
+	case "darwin":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		base = filepath.Join(home, "Library", "Application Support", "Claude")
+	case "linux":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		base = filepath.Join(home, ".config", "claude")
+	case "windows":
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			return "", fmt.Errorf("APPDATA not set")
+		}
+		base = filepath.Join(appData, "Claude")
+	default:
+		return "", fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+	}
+
+	path := filepath.Join(base, "settings.json")
+	return path, nil
+}
+
+func readJSON(path string) (map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// mergeHooks merges the uncompact hooks config into the existing settings,
+// without clobbering existing hook entries.
+func mergeHooks(existing, additions map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	for k, v := range existing {
+		result[k] = v
+	}
+	for k, v := range additions {
+		result[k] = v
+	}
+	return result
+}
+
+func printDiff(before, after map[string]interface{}) {
+	beforeBytes, _ := json.MarshalIndent(before, "", "  ")
+	afterBytes, _ := json.MarshalIndent(after, "", "  ")
+	fmt.Printf("Before:\n%s\n\nAfter:\n%s\n", string(beforeBytes), string(afterBytes))
+}

--- a/internal/output/render.go
+++ b/internal/output/render.go
@@ -1,0 +1,129 @@
+package output
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/supermodeltools/uncompact/internal/api"
+)
+
+const contextBombTemplate = `# Uncompact Context
+
+> Re-injected by Uncompact · {{.Timestamp}} · ~{{.EstimatedTokens}} tokens{{if .IsStale}} · ⚠ STALE: last updated {{.StaleAge}} ago{{end}}
+
+{{range .Sections}}{{if eq .Priority "required"}}
+## {{.Title}}
+
+{{.Content}}
+{{end}}{{end}}
+{{range .Sections}}{{if eq .Priority "optional"}}
+## {{.Title}}
+
+{{.Content}}
+{{end}}{{end}}`
+
+// ContextBombData is the template data for rendering the context bomb.
+type ContextBombData struct {
+	Timestamp       string
+	EstimatedTokens int
+	IsStale         bool
+	StaleAge        string
+	Sections        []api.GraphSection
+}
+
+// RenderContextBomb renders the graph into a Markdown context bomb capped at maxTokens.
+func RenderContextBomb(graph *api.Graph, maxTokens int) (string, error) {
+	if graph == nil {
+		return FallbackContext(), nil
+	}
+
+	isStale := time.Since(graph.FetchedAt) > graph.TTL
+	staleAge := ""
+	if isStale {
+		staleAge = formatAge(time.Since(graph.FetchedAt))
+	}
+
+	// Build sections list, respecting token budget
+	sections, totalTokens := selectSections(graph.Sections, maxTokens)
+
+	data := ContextBombData{
+		Timestamp:       graph.FetchedAt.Format("2006-01-02 15:04 UTC"),
+		EstimatedTokens: totalTokens,
+		IsStale:         isStale,
+		StaleAge:        staleAge,
+		Sections:        sections,
+	}
+
+	tmpl, err := template.New("context-bomb").Parse(contextBombTemplate)
+	if err != nil {
+		return "", fmt.Errorf("parsing template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("executing template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// FallbackContext returns minimal static context when the API and cache are both unavailable.
+func FallbackContext() string {
+	return strings.TrimSpace(`
+# Uncompact Context
+
+> ⚠ Uncompact could not reach the Supermodel API and no cached context is available.
+> Run \`uncompact status\` for details or \`uncompact run --force-refresh\` to retry.
+`) + "\n"
+}
+
+// selectSections picks sections to include within the token budget.
+// Required sections are always included first; optional sections fill the remainder.
+func selectSections(sections []api.GraphSection, maxTokens int) ([]api.GraphSection, int) {
+	var required, optional []api.GraphSection
+	for _, s := range sections {
+		if s.Priority == "required" {
+			required = append(required, s)
+		} else {
+			optional = append(optional, s)
+		}
+	}
+
+	var selected []api.GraphSection
+	remaining := maxTokens
+
+	for _, s := range required {
+		if s.Tokens > 0 && remaining-s.Tokens < 0 {
+			continue // skip even required sections if truly no budget left
+		}
+		selected = append(selected, s)
+		remaining -= s.Tokens
+	}
+
+	for _, s := range optional {
+		if remaining <= 0 {
+			break
+		}
+		if s.Tokens > 0 && s.Tokens > remaining {
+			continue
+		}
+		selected = append(selected, s)
+		remaining -= s.Tokens
+	}
+
+	totalTokens := maxTokens - remaining
+	return selected, totalTokens
+}
+
+func formatAge(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	return fmt.Sprintf("%dh", int(d.Hours()))
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"os"
+
+	"github.com/supermodeltools/uncompact/cmd"
+)
+
+func main() {
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Implements the initial Go CLI skeleton for Uncompact as specified in issue #1.

Closes #1

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released Uncompact CLI tool with installation, configuration, and context generation commands.
  * Added status, statistics, and logging commands for cache and usage monitoring.
  * Implemented local caching with graceful fallback when API is unavailable.

* **Documentation**
  * Added comprehensive README with setup instructions, prerequisites, and usage guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->