### PR TITLE
fix: correct context bomb zeros for lines and language counts

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -31,16 +31,10 @@ type Client struct {
 
 // SupermodelIR is the raw response from the Supermodel API /v1/graphs/supermodel endpoint.
 type SupermodelIR struct {
-	Repo     string           `json:"repo"`
-	Summary  irSummary        `json:"summary"`
-	Metadata irMetadata       `json:"metadata"`
-	Domains  []irDomain       `json:"domains"`
-}
-
-type irSummary struct {
-	FilesProcessed  int     `json:"filesProcessed"`
-	Functions       int     `json:"functions"`
-	PrimaryLanguage *string `json:"primaryLanguage"`
+	Repo     string         `json:"repo"`
+	Summary  map[string]any `json:"summary"`
+	Metadata irMetadata     `json:"metadata"`
+	Domains  []irDomain     `json:"domains"`
 }
 
 type irMetadata struct {
@@ -67,13 +61,21 @@ func (ir *SupermodelIR) toProjectGraph(projectName string) *ProjectGraph {
 	if len(ir.Metadata.Languages) > 0 {
 		lang = ir.Metadata.Languages[0]
 	}
-	if ir.Summary.PrimaryLanguage != nil && *ir.Summary.PrimaryLanguage != "" {
-		lang = *ir.Summary.PrimaryLanguage
+	if v, ok := ir.Summary["primaryLanguage"]; ok && v != nil {
+		if s, ok := v.(string); ok && s != "" {
+			lang = s
+		}
 	}
 
-	langMap := make(map[string]int, len(ir.Metadata.Languages))
-	for _, l := range ir.Metadata.Languages {
-		langMap[l] = 0 // count not available from API
+	// Extract integer fields from the free-form summary map.
+	// JSON numbers unmarshal as float64 in map[string]any.
+	summaryInt := func(key string) int {
+		if v, ok := ir.Summary[key]; ok {
+			if n, ok := v.(float64); ok {
+				return int(n)
+			}
+		}
+		return 0
 	}
 
 	domains := make([]Domain, 0, len(ir.Domains))
@@ -96,9 +98,9 @@ func (ir *SupermodelIR) toProjectGraph(projectName string) *ProjectGraph {
 		Language: lang,
 		Domains:  domains,
 		Stats: Stats{
-			TotalFiles:     ir.Summary.FilesProcessed,
-			TotalFunctions: ir.Summary.Functions,
-			Languages:      langMap,
+			TotalFiles:     summaryInt("filesProcessed"),
+			TotalFunctions: summaryInt("functions"),
+			Languages:      ir.Metadata.Languages,
 		},
 		UpdatedAt: time.Now(),
 	}
@@ -127,10 +129,9 @@ type Domain struct {
 
 // Stats holds codebase statistics.
 type Stats struct {
-	TotalFiles     int            `json:"total_files"`
-	TotalFunctions int            `json:"total_functions"`
-	TotalLines     int            `json:"total_lines"`
-	Languages      map[string]int `json:"languages,omitempty"`
+	TotalFiles     int      `json:"total_files"`
+	TotalFunctions int      `json:"total_functions"`
+	Languages      []string `json:"languages,omitempty"`
 }
 
 // JobStatus is the async envelope returned by the Supermodel API.

--- a/internal/template/render.go
+++ b/internal/template/render.go
@@ -21,7 +21,7 @@ const contextBombTmpl = `# Uncompact Context — {{.ProjectName}}
 **Language:** {{.Graph.Language}}{{if .Graph.Framework}}
 **Framework:** {{.Graph.Framework}}{{end}}{{if .Graph.Description}}
 **Description:** {{.Graph.Description}}{{end}}
-**Codebase:** {{.Graph.Stats.TotalFiles}} files · {{.Graph.Stats.TotalFunctions}} functions · {{.Graph.Stats.TotalLines}} lines
+**Codebase:** {{.Graph.Stats.TotalFiles}} files · {{.Graph.Stats.TotalFunctions}} functions
 {{- if .Graph.Stats.Languages}}
 
 **Languages:** {{languageList .Graph.Stats.Languages}}{{end}}
@@ -73,12 +73,8 @@ func Render(graph *api.ProjectGraph, projectName string, opts RenderOptions) (st
 
 	funcMap := gotmpl.FuncMap{
 		"join": strings.Join,
-		"languageList": func(langs map[string]int) string {
-			parts := make([]string, 0, len(langs))
-			for lang, count := range langs {
-				parts = append(parts, fmt.Sprintf("%s (%d)", lang, count))
-			}
-			return strings.Join(parts, ", ")
+		"languageList": func(langs []string) string {
+			return strings.Join(langs, ", ")
 		},
 	}
 


### PR DESCRIPTION
Remove `Stats.TotalLines` (not in API response), change `Stats.Languages` from `map[string]int` to `[]string`, and change `irSummary` from a typed struct to `map[string]any` to avoid silent zero-fills if API field names change.

Closes #7

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured how language statistics are displayed and processed
  * Simplified codebase metrics presentation by removing total lines metric
  * Updated summary data handling to use a more flexible format for improved extensibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->