### PR TITLE
feat: add critical files section to context bomb

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -76,9 +76,17 @@ type irSubdomain struct {
 // computeCriticalFiles derives the most-connected files by counting how many domains
 // reference each file as a key file. The top n files are returned, ranked descending.
 func computeCriticalFiles(domains []Domain, n int) []CriticalFile {
+	if n <= 0 {
+		return nil
+	}
 	counts := make(map[string]int)
 	for _, d := range domains {
+		seen := make(map[string]struct{}, len(d.KeyFiles))
 		for _, f := range d.KeyFiles {
+			if _, exists := seen[f]; exists {
+				continue
+			}
+			seen[f] = struct{}{}
 			counts[f]++
 		}
 	}

--- a/internal/template/render.go
+++ b/internal/template/render.go
@@ -132,11 +132,20 @@ func truncateToTokenBudget(
 
 	// Include critical files section before domain map — it's high-priority read order context.
 	if len(graph.CriticalFiles) > 0 {
-		criticalSection := buildCriticalFilesSection(graph.CriticalFiles)
-		criticalTokens := countTokens(criticalSection)
-		if criticalTokens <= remaining {
-			sb.WriteString(criticalSection)
-			remaining -= criticalTokens
+		header := "\n\n## Critical Files\n"
+		headerTokens := countTokens(header)
+		if headerTokens <= remaining {
+			sb.WriteString(header)
+			remaining -= headerTokens
+			for i, f := range graph.CriticalFiles {
+				line := fmt.Sprintf("%d. %s — %d relationships\n", i+1, f.Path, f.RelationshipCount)
+				lineTokens := countTokens(line)
+				if lineTokens > remaining {
+					break
+				}
+				sb.WriteString(line)
+				remaining -= lineTokens
+			}
 		}
 	}
 


### PR DESCRIPTION
Derives the most-connected files from domain key file references and renders them as a ranked read-order list in the context bomb output.

Closes #11

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added critical files identification, ranking the top-10 files by connection count across domains.
  * Critical files section now appears in project output before the domain map, listing numbered file paths with relationship counts for quick reference.
  * The section shows only when critical files exist and is subject to output truncation rules to fit display limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->