### PR TITLE
feat: show circular dependency warning in context bomb

### DIFF
--- a/cmd/pregen.go
+++ b/cmd/pregen.go
@@ -90,7 +90,7 @@ func pregenHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	apiClient := api.New(cfg.BaseURL, cfg.APIKey, debug, logFn)
-	graph, err := apiClient.GetGraph(ctx, proj.Name, zipData)
+	graph, err := fetchGraphWithCircularDeps(ctx, apiClient, proj.Name, zipData, logFn)
 	if err != nil {
 		logFn("[warn] API error: %v", err)
 		return nil
@@ -117,7 +117,7 @@ func pregenFetch(cfg *config.Config, proj *project.Info, logFn func(string, ...i
 	}
 
 	apiClient := api.New(cfg.BaseURL, cfg.APIKey, debug, logFn)
-	_, err = apiClient.GetGraph(ctx, proj.Name, zipData)
+	_, err = fetchGraphWithCircularDeps(ctx, apiClient, proj.Name, zipData, logFn)
 	if err != nil {
 		logFn("[warn] API error: %v", err)
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -124,7 +124,7 @@ func runHandler(cmd *cobra.Command, args []string) error {
 			// else: fall through to use stale cache
 		} else {
 			apiClient := api.New(cfg.BaseURL, cfg.APIKey, debug, logFn)
-			freshGraph, err := apiClient.GetGraph(ctx, proj.Name, zipData)
+			freshGraph, err := fetchGraphWithCircularDeps(ctx, apiClient, proj.Name, zipData, logFn)
 			if err != nil {
 				logFn("[warn] API error: %v", err)
 				if graph == nil {
@@ -195,7 +195,7 @@ func runWithoutCache(cfg *config.Config, proj *project.Info, logFn func(string, 
 	}
 
 	apiClient := api.New(cfg.BaseURL, cfg.APIKey, debug, logFn)
-	graph, err := apiClient.GetGraph(ctx, proj.Name, zipData)
+	graph, err := fetchGraphWithCircularDeps(ctx, apiClient, proj.Name, zipData, logFn)
 	if err != nil {
 		logFn("[warn] API error: %v", err)
 		if fallback {
@@ -216,6 +216,31 @@ func runWithoutCache(cfg *config.Config, proj *project.Info, logFn func(string, 
 
 	fmt.Print(output)
 	return nil
+}
+
+// fetchGraphWithCircularDeps calls GetGraph and GetCircularDependencies, storing
+// cycle count in Stats so it is cached alongside the graph.
+func fetchGraphWithCircularDeps(
+	ctx context.Context,
+	client *api.Client,
+	projectName string,
+	repoZip []byte,
+	logFn func(string, ...interface{}),
+) (*api.ProjectGraph, error) {
+	graph, err := client.GetGraph(ctx, projectName, repoZip)
+	if err != nil {
+		return nil, err
+	}
+
+	circDeps, err := client.GetCircularDependencies(ctx, projectName, repoZip)
+	if err != nil {
+		logFn("[warn] circular dependency check failed: %v", err)
+	} else if circDeps != nil {
+		graph.Stats.CircularDependencyCycles = len(circDeps.Cycles)
+		logFn("[debug] circular dependency cycles found: %d", graph.Stats.CircularDependencyCycles)
+	}
+
+	return graph, nil
 }
 
 // silentExit returns nil (success) so we never block Claude Code sessions.

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -219,9 +219,20 @@ type Domain struct {
 
 // Stats holds codebase statistics.
 type Stats struct {
-	TotalFiles     int      `json:"total_files"`
-	TotalFunctions int      `json:"total_functions"`
-	Languages      []string `json:"languages,omitempty"`
+	TotalFiles               int      `json:"total_files"`
+	TotalFunctions           int      `json:"total_functions"`
+	Languages                []string `json:"languages,omitempty"`
+	CircularDependencyCycles int      `json:"circular_dependency_cycles,omitempty"`
+}
+
+// CircularDependencyCycle represents a single circular import chain.
+type CircularDependencyCycle struct {
+	Cycle []string `json:"cycle"`
+}
+
+// CircularDependencyResponse is the result from the circular dependency endpoint.
+type CircularDependencyResponse struct {
+	Cycles []CircularDependencyCycle `json:"cycles"`
 }
 
 // JobStatus is the async envelope returned by the Supermodel API.
@@ -368,6 +379,128 @@ func (c *Client) GetGraph(ctx context.Context, projectName string, repoZip []byt
 	}
 
 	return nil, fmt.Errorf("job did not complete after %d attempts", maxPollAttempts)
+}
+
+// GetCircularDependencies submits the repo zip to the circular dependency endpoint
+// and returns the list of detected import cycles. Returns nil, nil if the endpoint
+// is unavailable. If available but no cycles are found, returns an empty response.
+func (c *Client) GetCircularDependencies(ctx context.Context, projectName string, repoZip []byte) (*CircularDependencyResponse, error) {
+	c.logFn("[debug] checking circular dependencies (%d bytes)", len(repoZip))
+
+	idempotencyKey := uuid.NewString()
+	deadline := time.Now().Add(maxPollDuration)
+
+	for attempt := 0; attempt < maxPollAttempts; attempt++ {
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("circular dependency job timed out after %v", maxPollDuration)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		var body bytes.Buffer
+		mw := multipart.NewWriter(&body)
+		_ = mw.WriteField("project_name", projectName)
+		fw, err := mw.CreateFormFile("file", "repo.zip")
+		if err != nil {
+			return nil, fmt.Errorf("creating multipart field: %w", err)
+		}
+		if _, err := fw.Write(repoZip); err != nil {
+			return nil, fmt.Errorf("writing zip: %w", err)
+		}
+		if err := mw.Close(); err != nil {
+			return nil, fmt.Errorf("closing multipart: %w", err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+			c.baseURL+"/v1/graphs/circular-dependencies", &body)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", mw.FormDataContentType())
+		req.Header.Set("X-Api-Key", c.apiKey)
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("User-Agent", "uncompact/1.0")
+		req.Header.Set("Idempotency-Key", idempotencyKey)
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("circular dependency request failed: %w", err)
+		}
+		respBody, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("reading response: %w", readErr)
+		}
+
+		c.logFn("[debug] circular dep poll attempt %d: HTTP %d", attempt+1, resp.StatusCode)
+
+		switch resp.StatusCode {
+		case http.StatusUnauthorized:
+			return nil, fmt.Errorf("authentication failed: check your API key at %s", config.DashboardURL)
+		case http.StatusPaymentRequired:
+			return nil, fmt.Errorf("subscription required: visit %s to subscribe", config.DashboardURL)
+		case http.StatusTooManyRequests:
+			return nil, fmt.Errorf("rate limit exceeded: please wait before retrying")
+		case http.StatusNotFound, http.StatusMethodNotAllowed:
+			// Endpoint not available — treat as no data
+			return nil, nil
+		case http.StatusOK, http.StatusAccepted:
+			// Continue to parse
+		default:
+			var errResp struct {
+				Message string `json:"message"`
+				Error   string `json:"error"`
+			}
+			_ = json.Unmarshal(respBody, &errResp)
+			msg := errResp.Message
+			if msg == "" {
+				msg = errResp.Error
+			}
+			if msg == "" {
+				msg = string(respBody)
+			}
+			return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, msg)
+		}
+
+		var jobResp JobStatus
+		if err := json.Unmarshal(respBody, &jobResp); err != nil {
+			return nil, fmt.Errorf("parsing response: %w", err)
+		}
+
+		c.logFn("[debug] circular dep job %s status: %s", jobResp.JobID, jobResp.Status)
+
+		switch jobResp.Status {
+		case "completed":
+			if jobResp.Result == nil {
+				return &CircularDependencyResponse{}, nil
+			}
+			var result CircularDependencyResponse
+			if err := json.Unmarshal(*jobResp.Result, &result); err != nil {
+				return nil, fmt.Errorf("parsing circular dependency result: %w", err)
+			}
+			return &result, nil
+		case "failed":
+			return nil, fmt.Errorf("circular dependency job failed: %s", jobResp.Error)
+		case "pending", "processing":
+			retryAfter := time.Duration(jobResp.RetryAfter) * time.Second
+			if retryAfter <= 0 {
+				retryAfter = 10 * time.Second
+			}
+			c.logFn("[debug] waiting %v before next circular dep poll", retryAfter)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(retryAfter):
+			}
+		default:
+			c.logFn("[debug] unknown circular dep job status: %s", jobResp.Status)
+		}
+	}
+
+	return nil, fmt.Errorf("circular dependency job did not complete after %d attempts", maxPollAttempts)
 }
 
 // ValidateKey checks if the API key is valid by probing the graphs endpoint.

--- a/internal/template/render.go
+++ b/internal/template/render.go
@@ -14,6 +14,9 @@ import (
 const contextBombTmpl = `# Uncompact Context — {{.ProjectName}}
 
 > Injected by Uncompact at {{.Timestamp}}{{if .Stale}} | ⚠️ STALE: last updated {{.StaleDuration}}{{end}}
+{{- if .Graph.Stats.CircularDependencyCycles}}
+> ⚠️ {{.Graph.Stats.CircularDependencyCycles}} circular dependency {{if eq .Graph.Stats.CircularDependencyCycles 1}}cycle{{else}}cycles{{end}} detected
+{{- end}}
 
 ## Project Overview
 
@@ -103,7 +106,7 @@ func Render(graph *api.ProjectGraph, projectName string, opts RenderOptions) (st
 	}
 
 	// If over budget, truncate domains to fit
-	return truncateToTokenBudget(graph, projectName, opts.MaxTokens)
+	return truncateToTokenBudget(graph, projectName, opts.MaxTokens, graph.Stats.CircularDependencyCycles)
 }
 
 // truncateToTokenBudget progressively drops lower-priority content to fit the token budget.
@@ -111,14 +114,24 @@ func truncateToTokenBudget(
 	graph *api.ProjectGraph,
 	projectName string,
 	maxTokens int,
+	circularCycles int,
 ) (string, int, error) {
 
 	// Build a minimal required header
-	required := fmt.Sprintf(`# Uncompact Context — %s
-
-**Language:** %s · **Files:** %d · **Functions:** %d`,
-		projectName, graph.Language, graph.Stats.TotalFiles, graph.Stats.TotalFunctions,
-	)
+	var hdr strings.Builder
+	hdr.WriteString(fmt.Sprintf("# Uncompact Context — %s\n\n", projectName))
+	if circularCycles > 0 {
+		label := "cycles"
+		if circularCycles == 1 {
+			label = "cycle"
+		}
+		hdr.WriteString(fmt.Sprintf("> ⚠️ %d circular dependency %s detected\n\n", circularCycles, label))
+	}
+	hdr.WriteString(fmt.Sprintf(
+		"**Language:** %s · **Files:** %d · **Functions:** %d",
+		graph.Language, graph.Stats.TotalFiles, graph.Stats.TotalFunctions,
+	))
+	required := hdr.String()
 
 	reqTokens := countTokens(required)
 	if reqTokens > maxTokens {


### PR DESCRIPTION
Adds circular dependency detection via `/v1/graphs/circular-dependencies`. Renders a blockquote warning when cycles exist. Cycle count is stored in `Stats.CircularDependencyCycles` so cache hits serve it with zero extra API calls.

Closes #12

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reports now include circular dependency counts when detected; analysis is collected automatically without interrupting processing.
  * Circular dependency counts are shown in compact/summary headers and considered when trimming long summaries.
  * Summary output adds a Tech stack line (external dependencies) when present.
  * Domains/subdomains are rendered as detailed lists; codebase summary shows Files and Functions counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->