### PR TITLE
ci: add automation workflows and CLAUDE.md

### DIFF
--- a/.github/workflows/claude-auto-assign.yml
+++ b/.github/workflows/claude-auto-assign.yml
@@ -1,0 +1,22 @@
+name: Auto-assign Claude on new issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  tag-claude:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Comment to trigger Claude
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '@claude please implement this issue'
+            });

--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -1,0 +1,78 @@
+name: Claude PR Shepherd
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+jobs:
+  shepherd:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run Claude PR Shepherd
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_tools: 'Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh pr merge:*),Bash(gh pr checks:*),Bash(gh api:*),Bash(git *),Bash(go build:*),Bash(go vet:*),Bash(go mod tidy:*),Edit,Write,Read,Glob,Grep'
+          prompt: |
+            You are a PR shepherd. Your job is to get open pull requests reviewed, fixed, and merged.
+
+            ## Step 1: Find open PRs
+            Run: gh pr list --repo ${{ github.repository }} --state open --json number,title,headRefName,isDraft,reviewDecision,mergeable --limit 20
+
+            Skip any PRs that are drafts.
+
+            ## Step 2: For each open PR
+
+            ### Check CodeRabbit comments
+            Fetch unresolved review comments:
+              gh api repos/${{ github.repository }}/pulls/{number}/comments --jq '[.[] | select(.user.login == "coderabbitai[bot]") | {id, path, line, body, in_reply_to_id}]'
+
+            Only look at top-level comments (no `in_reply_to_id`). For each unresolved comment:
+            - Check out the PR branch: `git fetch origin {branch} && git checkout {branch}`
+            - Read the file at the relevant path
+            - Determine if the comment is already addressed (the code may have been fixed since the comment was posted)
+            - If not addressed: apply the fix, then stage and commit with message `fix: address CodeRabbit comment on {path}`
+            - If already addressed: reply to the comment via `gh api repos/${{ github.repository }}/pulls/{number}/comments --method POST` explaining it's resolved
+
+            ### Check CI status
+            Run: gh pr checks {number} --repo ${{ github.repository }}
+
+            If any checks are failing:
+            - Read the failure logs via `gh run view` or `gh api`
+            - Fix the root cause if it's a code issue
+            - Do not merge if CI is red
+
+            ### Attempt merge
+            If all of the following are true:
+            - CI checks passing
+            - No unresolved CodeRabbit comments
+            - PR is not a draft
+            - `mergeable` is not `CONFLICTING`
+
+            Then merge: gh pr merge {number} --repo ${{ github.repository }} --squash --auto
+
+            If there are merge conflicts, resolve them by checking out the branch, rebasing onto the base branch, fixing conflicts, and force-pushing.
+
+            ## Rules
+            - Work through PRs one at a time
+            - Make focused, minimal commits — one commit per CodeRabbit comment addressed
+            - Never force-push to main/master
+            - If a CodeRabbit comment requires a design decision beyond your judgement, leave it alone and move on
+            - Do not approve your own PRs — only merge when CI is green and CodeRabbit comments are resolved

--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -1,0 +1,47 @@
+name: Claude Proactive Analysis
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude proactive analysis
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_tools: 'Bash(gh issue list:*),Bash(gh issue create:*),Bash(cat:*),Bash(find:*),Bash(go build:*),Bash(go vet:*)'
+          prompt: |
+            You are a proactive engineering assistant reviewing the Uncompact codebase for things to improve.
+
+            First, run `gh issue list --repo ${{ github.repository }} --state open --limit 50 --json title,body` to see what is already tracked. Do not create duplicates.
+
+            Then explore the codebase and look for:
+            - Bugs: logic errors, unhandled errors, race conditions, edge cases
+            - Missing tests
+            - Performance issues
+            - Security concerns
+            - Feature gaps (things the codebase is clearly building toward but hasn't finished)
+            - TODO/FIXME comments in code
+
+            For each finding, create a GitHub issue using:
+              gh issue create --repo ${{ github.repository }} --title "..." --body "..."
+
+            Rules:
+            - Create at most 3 issues per run to avoid spam
+            - Only create issues for concrete, actionable findings — no vague suggestions
+            - Include specific file paths and line numbers in the issue body
+            - Label bugs as "bug", features as "enhancement" using --label flag
+            - Do not create issues that duplicate anything already open

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,14 +36,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          allowed_tools: 'Bash(gh pr create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh issue:*),Bash(gh api:*),Bash(git *),Bash(go build:*),Bash(go vet:*),Bash(go mod tidy:*),Edit,Write,Read,Glob,Grep'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# Uncompact — Claude Instructions
+
+## Pull Requests
+
+When asked to implement something and raise a PR, always create the PR using `gh pr create`. Never substitute a "Create PR →" compare link. The command to use:
+
+```
+gh pr create \
+  --repo supermodeltools/Uncompact \
+  --title "..." \
+  --body "..." \
+  --base main \
+  --head <branch>
+```
+
+Always run this as the final step. The PR must exist before marking the task complete.
+
+## Development
+
+- Language: Go 1.22
+- Build: `go build ./...`
+- Lint: `go vet ./...`
+- No test suite yet — at minimum verify `go build ./...` passes before committing
+
+## Branch naming
+
+`claude/issue-{number}-{YYYYMMDD}-{HHMM}`


### PR DESCRIPTION
These files were pushed after PR #6 was already merged, so they never landed on main.

## Workflows
- **claude-auto-assign.yml** — posts `@claude` comment on every new issue, triggering auto-implementation
- **claude-proactive.yml** — runs hourly, scans for bugs/features, files up to 3 issues per run  
- **claude-pr-shepherd.yml** — runs every 15 minutes, addresses CodeRabbit comments and merges clean PRs
- **claude.yml** — adds explicit `allowed_tools` including `gh pr create` so Claude stops posting compare links

## CLAUDE.md
Standing instruction: always use `gh pr create`, never substitute a compare link.

Once this merges, the scheduled workflows activate and PRs #13–18 should get shepherded automatically.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GitHub Actions workflow to trigger Claude automation on new issues.
  * Added GitHub Actions workflow for automated PR management and merging.
  * Added GitHub Actions workflow for periodic codebase analysis and automated issue creation.

* **Documentation**
  * Added Claude workflow guidance and development instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->