### PR TITLE
fix(ci): allow claude[bot] to trigger Claude Code workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # Allow the claude-auto-assign bot to trigger this workflow
+          allowed_bots: "claude[bot]"
+
           additional_permissions: |
             actions: read
 


### PR DESCRIPTION
## Summary

- Adds `allowed_bots: "claude[bot]"` to `claude.yml` so `claude-auto-assign.yml` can trigger it
- Without this, auto-assigned issues fail with: *"Workflow initiated by non-human actor: claude (type: Bot)"*

## Test plan
- [ ] Confirm next auto-assigned issue triggers Claude successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to enable automated process enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->