### PR TITLE
feat: UNCOMPACT_DASHBOARD_URL override and --debug logging for auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This installs both hooks automatically:
 - **`SessionStart`** — runs `scripts/setup.sh` which auto-installs the `uncompact` binary via `go install` if not already present.
 - **`Stop`** — runs `scripts/uncompact-hook.sh` which reinjects context after every compaction event.
 
-> **Note:** After plugin installation, authenticate once with `uncompact auth login` to connect your Supermodel API key. That's it — no manual binary install or hook setup required.
+> **Note:** After plugin installation, run `uncompact auth login` once to authenticate. This also ensures hooks are installed — no separate `uncompact install` step needed.
 
 ### CI / GitHub Actions
 
@@ -65,22 +65,33 @@ env:
 
 ## Quick Start
 
-### 1. Install
-
-**Via npm (recommended):**
+### Via npm (recommended)
 
 ```bash
-# Install CLI and automatically configure Claude Code hooks
-npm install -g uncompact
+npm install -g uncompact --foreground-scripts
 ```
 
-*Note: npm might hide the configuration output. You can verify the installation with `uncompact verify-install`.*
+That's it. The installer downloads the binary, opens your browser for GitHub authentication, and installs the Claude Code hooks — all in one step.
 
-**Or run/install without global installation:**
+> `--foreground-scripts` is required so the interactive auth prompt is visible in your terminal.
+
+### Via Go or manual binary
 
 ```bash
-# This will show full interactive output
-npx uncompact install
+go install github.com/supermodeltools/uncompact@latest
+# then:
+uncompact auth login
+```
+
+`auth login` opens your browser for GitHub OAuth, saves your API key, and installs the Claude Code hooks automatically.
+
+**Or download a binary** from [Releases](https://github.com/supermodeltools/Uncompact/releases) and run `uncompact auth login`.
+
+### Verify
+
+```bash
+uncompact verify-install
+uncompact run --debug
 ```
 
 ### 🗑 Uninstall
@@ -95,39 +106,7 @@ To **completely remove** Uncompact configuration and cached data:
 
 ```bash
 uncompact uninstall --total
-```
-
-*Note: After running the above, you can remove the CLI itself with `npm uninstall -g uncompact`.*
-
-**Via Go:**
-
-```bash
-go install github.com/supermodeltools/uncompact@latest
-```
-
-**Or download a binary** from [Releases](https://github.com/supermodeltools/Uncompact/releases).
-
-### 2. Authenticate
-
-```bash
-uncompact auth login
-```
-
-This opens [dashboard.supermodeltools.com/api-keys/](https://dashboard.supermodeltools.com/api-keys/) where you can subscribe and generate an API key.
-
-### 3. Install Claude Code Hooks
-
-```bash
-uncompact install
-```
-
-This auto-detects your Claude Code `settings.json`, shows a diff, and merges the hooks non-destructively.
-
-### 4. Verify
-
-```bash
-uncompact verify-install
-uncompact run --debug
+npm uninstall -g uncompact
 ```
 
 ## CLI Reference
@@ -164,6 +143,8 @@ uncompact cache clear --project  # Clear only the current project's cache
 | Variable | Description |
 |----------|-------------|
 | `SUPERMODEL_API_KEY` | Supermodel API key (overrides config file) |
+| `UNCOMPACT_API_URL` | Override the API base URL (e.g. for staging) |
+| `UNCOMPACT_DASHBOARD_URL` | Override the dashboard base URL (e.g. for staging) |
 
 ### Config File
 
@@ -244,7 +225,7 @@ uncompact/
 |---------|--------|
 | Default TTL | 15 minutes |
 | Stale cache | Served with `⚠️ STALE` warning; fresh fetch attempted |
-| API unavailable | Serve most recent cache entry silently |
+| API unreachable | Fail fast on connection error; serve stale cache if available |
 | No cache + API down | Silent exit 0 (never blocks Claude Code) |
 | Storage growth | Auto-prune entries older than 30 days |
 | Force refresh | `--force-refresh` flag |

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -139,11 +139,18 @@ func authLoginBrowser(cfg *config.Config) (string, error) {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
-		logFn("[debug] auth: callback received: %s", r.URL.String())
+		// Log the callback path and which query params are present, but never
+		// their values — key and state are secrets.
+		q := r.URL.Query()
+		params := make([]string, 0, len(q))
+		for k := range q {
+			params = append(params, k)
+		}
+		logFn("[debug] auth: callback received: %s (params: %v)", r.URL.Path, params)
 
 		gotState := r.URL.Query().Get("state")
 		if gotState != state {
-			logFn("[debug] auth: state mismatch — got %q, expected %q", gotState, state)
+			logFn("[debug] auth: state mismatch (CSRF check failed)")
 			http.Error(w, "Invalid state parameter", http.StatusForbidden)
 			resultCh <- callbackResult{err: fmt.Errorf("state mismatch (possible CSRF)")}
 			return
@@ -182,7 +189,7 @@ func authLoginBrowser(cfg *config.Config) (string, error) {
 	}()
 
 	dashURL := fmt.Sprintf("%s?port=%d&state=%s", config.EffectiveCLIAuthURL(), port, state)
-	logFn("[debug] auth: dashboard URL: %s", dashURL)
+	logFn("[debug] auth: opening dashboard (port=%d, state=<redacted>)", port)
 	fmt.Println("Opening your browser to sign in...")
 	fmt.Printf("  %s\n\n", dashURL)
 	fmt.Println("Waiting for authentication (this will timeout in 2 minutes)...")

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -16,6 +17,7 @@ import (
 	"github.com/supermodeltools/uncompact/internal/api"
 	"github.com/supermodeltools/uncompact/internal/cache"
 	"github.com/supermodeltools/uncompact/internal/config"
+	"github.com/supermodeltools/uncompact/internal/hooks"
 	"golang.org/x/term"
 )
 
@@ -277,7 +279,8 @@ func authLoginManual(cfg *config.Config) error {
 	return saveAndCacheKey(cfg, key)
 }
 
-// saveAndCacheKey encrypts and saves the key, then updates the auth cache.
+// saveAndCacheKey encrypts and saves the key, updates the auth cache, then
+// automatically installs the Claude Code hooks so auth login is a one-step setup.
 func saveAndCacheKey(cfg *config.Config, key string) error {
 	if os.Getenv(config.EnvAPIKey) != "" {
 		fmt.Println()
@@ -304,9 +307,61 @@ func saveAndCacheKey(cfg *config.Config, key string) error {
 	} else {
 		fmt.Println("\nAPI key saved.")
 	}
+
+	// Auto-install hooks so auth login is a complete one-step setup.
 	fmt.Println()
-	fmt.Println("Next: run 'uncompact install' to add hooks to Claude Code.")
+	autoInstallHooks()
 	return nil
+}
+
+// autoInstallHooks installs the Claude Code hooks as part of the auth login
+// flow. If already installed it confirms silently. If not, it shows the diff,
+// prompts for confirmation, and applies — matching the behaviour of
+// `uncompact install` but without requiring a separate command.
+func autoInstallHooks() {
+	settingsPath, err := hooks.FindSettingsFile()
+	if err != nil {
+		fmt.Println("Could not find Claude Code settings.json — run 'uncompact install' manually.")
+		return
+	}
+
+	result, err := hooks.Install(settingsPath, true) // dry-run to get diff
+	if err != nil {
+		fmt.Printf("Could not check hook status: %v\n", err)
+		fmt.Println("Run 'uncompact install' manually.")
+		return
+	}
+
+	if result.AlreadySet {
+		fmt.Println("✓ Claude Code hooks already installed.")
+		return
+	}
+
+	fmt.Println("The following changes will be made to Claude Code settings.json:")
+	fmt.Println()
+	fmt.Println(result.Diff)
+	fmt.Print("Install hooks now? [y/N]: ")
+
+	scanner := bufio.NewScanner(os.Stdin)
+	if !scanner.Scan() {
+		fmt.Println("Skipped. Run 'uncompact install' to add hooks later.")
+		return
+	}
+	answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
+	if answer != "y" && answer != "yes" {
+		fmt.Println("Skipped. Run 'uncompact install' to add hooks later.")
+		return
+	}
+
+	if _, err := hooks.Install(settingsPath, false); err != nil {
+		fmt.Printf("Hook install failed: %v\n", err)
+		fmt.Println("Run 'uncompact install' manually.")
+		return
+	}
+
+	fmt.Println()
+	fmt.Println("✓ Claude Code hooks installed.")
+	fmt.Println("  Uncompact will now reinject context automatically after compaction.")
 }
 
 func authStatusHandler(cmd *cobra.Command, args []string) error {

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -115,6 +115,8 @@ func authLoginHandler(cmd *cobra.Command, args []string) error {
 // authLoginBrowser starts a localhost callback server, opens the dashboard,
 // and waits for the key to arrive via redirect.
 func authLoginBrowser(cfg *config.Config) (string, error) {
+	logFn := makeLogger()
+
 	state, err := generateState()
 	if err != nil {
 		return "", fmt.Errorf("generating state: %w", err)
@@ -125,6 +127,7 @@ func authLoginBrowser(cfg *config.Config) (string, error) {
 		return "", fmt.Errorf("starting callback server: %w", err)
 	}
 	port := listener.Addr().(*net.TCPAddr).Port
+	logFn("[debug] auth: callback server listening on 127.0.0.1:%d", port)
 
 	type callbackResult struct {
 		key string
@@ -134,7 +137,11 @@ func authLoginBrowser(cfg *config.Config) (string, error) {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("state") != state {
+		logFn("[debug] auth: callback received: %s", r.URL.String())
+
+		gotState := r.URL.Query().Get("state")
+		if gotState != state {
+			logFn("[debug] auth: state mismatch — got %q, expected %q", gotState, state)
 			http.Error(w, "Invalid state parameter", http.StatusForbidden)
 			resultCh <- callbackResult{err: fmt.Errorf("state mismatch (possible CSRF)")}
 			return
@@ -146,11 +153,13 @@ func authLoginBrowser(cfg *config.Config) (string, error) {
 			if errMsg == "" {
 				errMsg = "no key received"
 			}
+			logFn("[debug] auth: callback error — %s", errMsg)
 			http.Error(w, errMsg, http.StatusBadRequest)
 			resultCh <- callbackResult{err: fmt.Errorf("dashboard returned error: %s", errMsg)}
 			return
 		}
 
+		logFn("[debug] auth: key received (%d chars)", len(key))
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, successHTML)
@@ -170,7 +179,8 @@ func authLoginBrowser(cfg *config.Config) (string, error) {
 		_ = server.Shutdown(ctx)
 	}()
 
-	dashURL := fmt.Sprintf("%s?port=%d&state=%s", config.DashboardCLIAuthURL, port, state)
+	dashURL := fmt.Sprintf("%s?port=%d&state=%s", config.EffectiveCLIAuthURL(), port, state)
+	logFn("[debug] auth: dashboard URL: %s", dashURL)
 	fmt.Println("Opening your browser to sign in...")
 	fmt.Printf("  %s\n\n", dashURL)
 	fmt.Println("Waiting for authentication (this will timeout in 2 minutes)...")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	EnvAPIKey    = "SUPERMODEL_API_KEY"
-	EnvMode      = "UNCOMPACT_MODE"
-	APIBaseURL   = "https://api.supermodeltools.com"
+	EnvAPIKey        = "SUPERMODEL_API_KEY"
+	EnvMode          = "UNCOMPACT_MODE"
+	EnvDashboardURL  = "UNCOMPACT_DASHBOARD_URL" // override base dashboard URL for staging
+	APIBaseURL       = "https://api.supermodeltools.com"
 	DashboardURL        = "https://dashboard.supermodeltools.com"
 	DashboardKeyURL     = "https://dashboard.supermodeltools.com/api-keys/"
 	DashboardCLIAuthURL = "https://dashboard.supermodeltools.com/cli-auth/"
@@ -39,6 +40,16 @@ type Config struct {
 
 	// Source indicates where the API key was loaded from.
 	Source string `json:"-"`
+}
+
+// EffectiveCLIAuthURL returns the dashboard CLI auth URL, allowing the base
+// domain to be overridden via UNCOMPACT_DASHBOARD_URL for staging or local
+// development. Example: UNCOMPACT_DASHBOARD_URL=https://staging.dashboard.supermodeltools.com
+func EffectiveCLIAuthURL() string {
+	if override := os.Getenv(EnvDashboardURL); override != "" {
+		return strings.TrimRight(override, "/") + "/cli-auth/"
+	}
+	return DashboardCLIAuthURL
 }
 
 // ConfigDir returns the XDG-compatible config directory.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ const (
 	EnvAPIKey        = "SUPERMODEL_API_KEY"
 	EnvMode          = "UNCOMPACT_MODE"
 	EnvDashboardURL  = "UNCOMPACT_DASHBOARD_URL" // override base dashboard URL for staging
+	EnvAPIURL        = "UNCOMPACT_API_URL"        // override API base URL for staging
 	APIBaseURL       = "https://api.supermodeltools.com"
 	DashboardURL        = "https://dashboard.supermodeltools.com"
 	DashboardKeyURL     = "https://dashboard.supermodeltools.com/api-keys/"
@@ -205,7 +206,10 @@ func Load(flagAPIKey string) (*Config, error) {
 	}
 
 	// Apply defaults for any fields not set by file/env/flag.
-	if cfg.BaseURL == "" {
+	// UNCOMPACT_API_URL overrides the API base URL (useful for staging).
+	if envAPIURL := os.Getenv(EnvAPIURL); envAPIURL != "" {
+		cfg.BaseURL = strings.TrimRight(envAPIURL, "/")
+	} else if cfg.BaseURL == "" {
 		cfg.BaseURL = APIBaseURL
 	}
 	if cfg.MaxTokens <= 0 {

--- a/npm/install.js
+++ b/npm/install.js
@@ -187,27 +187,32 @@ async function main() {
     log(`[uncompact] Installed to ${destPath}\n\n`);
   }
 
-  // Automatically install Claude Code hooks
-  log("[uncompact] Configuring Claude Code hooks...\n");
+  // Check if already authenticated so we can decide what to run.
+  let isAuthenticated = false;
   try {
-    execFileSync(destPath, ["install", "--yes"], { stdio: "inherit" });
+    const out = execFileSync(destPath, ["auth", "status"], { stdio: "pipe" }).toString();
+    isAuthenticated = out.includes("authenticated");
   } catch (err) {
-    log("[uncompact] Note: Automatic hook configuration skipped or failed. Run manually if needed:\n");
-    log("  uncompact install\n");
+    // binary failed or not runnable — fall through to install
   }
 
-  // Show status to verify setup
-  try {
-    console.log();
-    execFileSync(destPath, ["status"], { stdio: "inherit" });
-  } catch (err) {
+  if (isAuthenticated) {
+    // Existing user (upgrade): just make sure hooks are current.
+    log("[uncompact] Already authenticated. Ensuring Claude Code hooks are installed...\n");
     try {
-      execFileSync(destPath, [], { stdio: "inherit" });
-    } catch (e) {}
+      execFileSync(destPath, ["install", "--yes"], { stdio: "inherit" });
+    } catch (err) {
+      log("[uncompact] Note: hook configuration skipped. Run 'uncompact install' manually if needed.\n");
+    }
+  } else {
+    // Fresh install: auth login handles both authentication and hook installation.
+    log("[uncompact] Starting setup...\n\n");
+    try {
+      execFileSync(destPath, ["auth", "login"], { stdio: "inherit" });
+    } catch (err) {
+      log("[uncompact] Setup skipped or failed. Run 'uncompact auth login' to complete setup.\n");
+    }
   }
-
-  log("\n");
-  log("[uncompact] To authenticate: run 'uncompact auth login'\n");
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Problem

When the browser freezes after GitHub auth, there was no way to:
1. Reproduce the issue against staging (dashboard URL was a hardcoded constant)
2. See where in the callback flow things were breaking (no debug output)

## Changes

### 1. \`UNCOMPACT_DASHBOARD_URL\` env var

Overrides the dashboard base domain used to build the CLI auth URL. No recompile needed for staging tests:

\`\`\`sh
UNCOMPACT_DASHBOARD_URL=https://staging.dashboard.supermodeltools.com uncompact auth login
\`\`\`

Implemented in \`config.EffectiveCLIAuthURL()\` — falls back to the production constant when the env var is not set.

### 2. \`--debug\` wired into \`authLoginBrowser\`

Running \`uncompact auth login --debug\` now emits:

\`\`\`
[debug] auth: callback server listening on 127.0.0.1:PORT
[debug] auth: dashboard URL: https://staging.dashboard.../cli-auth/?port=PORT&state=STATE
[debug] auth: callback received: /callback?state=...&key=...
[debug] auth: key received (N chars)
\`\`\`

If the browser freezes before redirecting back, the callback line never appears — pointing at the dashboard side. If it appears but with a wrong state or error param, it points at a specific mismatch.

## How to debug the staging freeze

\`\`\`sh
UNCOMPACT_DASHBOARD_URL=https://staging.dashboard.supermodeltools.com \
  uncompact auth login --debug
\`\`\`

Watch the output:
- Callback server starts → dashboard URL logged → browser opens
- If **no callback line appears** after GitHub auth completes: the dashboard is not redirecting to localhost (staging-side bug)
- If **callback received** but \`state mismatch\`: the state param is being dropped or mangled by the staging dashboard
- If **callback received** but \`error=...\`: the dashboard is explicitly sending an error param; check what it says
- If **key received** but auth still feels broken: the issue is in key validation, not the OAuth redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive prompt to detect and optionally install local editor hooks for the code assistant, showing a preview and confirming success.

* **Improvements**
  * Allow overriding dashboard and API base URLs via UNCOMPACT_DASHBOARD_URL and UNCOMPACT_API_URL.
  * Enhanced authentication logging and debug messages for browser-based login.
  * Post-install now conditionally runs hook installation or initiates auth based on authentication state.

* **Documentation**
  * Updated docs to reflect combined auth/install flow and new environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->